### PR TITLE
Fix protobuf warnning

### DIFF
--- a/chirpstack_api_wrapper/requirements.txt
+++ b/chirpstack_api_wrapper/requirements.txt
@@ -1,2 +1,3 @@
 chirpstack-api==4.*
 grpcio==1.*
+protobuf~=5.0

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import find_packages, setup
 
-VERSION = '0.1.0'
+VERSION = '0.1.1'
 
 setup(
     name='chirpstack_api_wrapper',


### PR DESCRIPTION
This pull request includes updates to dependencies and a version bump for the `chirpstack_api_wrapper` package. The most important changes are listed below:

### Dependency Updates:
* Added `protobuf~=5.0` to the `requirements.txt` file to specify compatibility with the 5.x series of the `protobuf` library.

Fixed this warning:
```
UserWarning: Protobuf gencode version 5.29.0 is exactly one major version older than the runtime version X.X.X at chirpstack-api/api/relay.proto. Please update the gencode to avoid compatibility violations in the next runtime release.
```